### PR TITLE
Meter cumulative import energy using meterread

### DIFF
--- a/app.json
+++ b/app.json
@@ -76,11 +76,13 @@
       },
       "class": "other",
       "capabilities": [
+        "meter_power.imported",
         "measure_power",
         "tariff"
       ],
       "energy": {
-        "cumulative": true
+        "cumulative": true,
+        "cumulativeImportedCapability": "meter_power.imported"
       },
       "platforms": [
         "local"

--- a/drivers/smart-meter/device.js
+++ b/drivers/smart-meter/device.js
@@ -22,6 +22,11 @@ class GlowmarktUKSmartMeter_device extends Device {
       headers: { 'Content-Type': 'application/json', 'token': token, 'applicationId': BRIGHT_APP_ID }
     }).then(r => r.json());
 
+	const fetchMeterReading = (token) => fetch(`https://api.glowmarkt.com/api/v0-1/resource/${elec_cons_res}/meterread`, {
+	  method: 'GET',
+	  headers: { 'Content-Type': 'application/json', 'token': token, 'applicationId': BRIGHT_APP_ID }
+	}).then(r => r.json());
+
     const fetchTariff = (token) => fetch(`https://api.glowmarkt.com/api/v0-1/resource/${elec_cons_res}/tariff`, {
       method: 'GET',
       headers: { 'Content-Type': 'application/json', 'token': token, 'applicationId': BRIGHT_APP_ID }
@@ -30,16 +35,29 @@ class GlowmarktUKSmartMeter_device extends Device {
     const updateDevice = async () => {
       try {
         let token = this.getStoreValue('token');
-        let resource = await fetchCurrentPower(token);
-        if (resource.error) {
+
+        let powerRes = await fetchCurrentPower(token);
+        if (powerRes.error) {
           this.log('Power API returned error, attempting token refresh');
           token = await this.refreshToken();
           if (!token) throw new Error('Token refresh failed');
-          resource = await fetchCurrentPower(token);
-          if (resource.error) throw new Error(`Power API error after token refresh: ${JSON.stringify(resource.error)}`);
+          powerRes = await fetchCurrentPower(token);
+          if (powerRes.error) throw new Error(`Power API error after token refresh: ${JSON.stringify(powerRes.error)}`);
         }
         if (!this.getAvailable()) this.setAvailable().catch(this.error);
-        this.setCapabilityValue('measure_power', resource.data[0][1]).catch(this.error);
+        this.setCapabilityValue('measure_power', powerRes.data[0][1]).catch(this.error);
+
+		let energyRes = await fetchMeterReading(token);
+		if (energyRes.error) {
+		  this.log('Meter read API returned error, attempting token refresh');
+		  token = await this.refreshToken();
+		  if (!token) throw new Error('Token refresh failed');
+		  energyRes = await fetchCurrentPower(token);
+		  if (energyRes.error) throw new Error(`Meter read API error after token refresh: ${JSON.stringify(energyRes.error)}`);
+		}
+		if (!this.getAvailable()) this.setAvailable().catch(this.error);
+		let kWh = energyRes.data[0][1] / 1000;
+		this.setCapabilityValue('meter_power.imported', kWh).catch(this.error);
       } catch (error) {
         this.error('updateDevice failed:', error);
         if (this.getAvailable()) {

--- a/drivers/smart-meter/device.js
+++ b/drivers/smart-meter/device.js
@@ -52,7 +52,7 @@ class GlowmarktUKSmartMeter_device extends Device {
 		  this.log('Meter read API returned error, attempting token refresh');
 		  token = await this.refreshToken();
 		  if (!token) throw new Error('Token refresh failed');
-		  energyRes = await fetchCurrentPower(token);
+		  energyRes = await fetchMeterReading(token);
 		  if (energyRes.error) throw new Error(`Meter read API error after token refresh: ${JSON.stringify(energyRes.error)}`);
 		}
 		if (!this.getAvailable()) this.setAvailable().catch(this.error);

--- a/drivers/smart-meter/driver.compose.json
+++ b/drivers/smart-meter/driver.compose.json
@@ -4,10 +4,13 @@
   },
   "class": "other",
   "capabilities": [
-    "measure_power","tariff"
+    "meter_power.imported",
+    "measure_power",
+	"tariff"
   ],
   "energy": {
-    "cumulative": true
+    "cumulative": true,
+	"cumulativeImportedCapability": "meter_power.imported"
   },
   "platforms": [
     "local"


### PR DESCRIPTION
This is a simple PR that hits the Glowmarkt API's `/resource/{id}/meterread` endpoint and logs that as a cumulative import meter read in Homey Energy. It does this at the same time as the poll for the current power level.

This works to track total imported energy, and gets rid of the warning in the Energy tab that the meter only supports real-time readings. I've tested this with my meter at home and it looks to be working successfully.

I imagine it would be relatively straightforward to add export readings in a similar way, but I don't have any stuff in my house that can export to the grid at the moment so I haven't implemented it!